### PR TITLE
fix(Field): make textarea fields resize properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@makesenseorg/design-system",
-  "version": "1.16.3",
+  "version": "1.16.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makesenseorg/design-system",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "engines": {
     "node": "14.x"
   },

--- a/src/system/components/molecules/field/Field.vue
+++ b/src/system/components/molecules/field/Field.vue
@@ -394,8 +394,8 @@ export default {
     };
   },
   methods: {
-    onInput() {
-      this.resize();
+    onInput($event) {
+      this.resize($event);
       this.$emit("input", this.theValue);
     },
     onClickLabel: function() {


### PR DESCRIPTION
On avait l'erreur `TypeError: Cannot read properties of undefined (reading 'target')` car on appelait la fonction resize sans argument.