### PR TITLE
fix(Icon): comply with axe 'svg-img-alt' accessibility rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@makesenseorg/design-system",
-  "version": "1.17.7",
+  "version": "1.17.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makesenseorg/design-system",
-  "version": "1.17.14",
+  "version": "1.17.15",
   "engines": {
     "node": "14.x"
   },

--- a/src/system/components/atoms/icon/Icon.vue
+++ b/src/system/components/atoms/icon/Icon.vue
@@ -1,7 +1,7 @@
 <template>
   <svg
     :class="`icon icon-${getIcon} icon--color-${color}`"
-    role="img"
+    :role="alt ? 'img' : null"
     xmlns="http://www.w3.org/2000/svg"
     :width="size"
     :height="size"


### PR DESCRIPTION
Voir : https://dequeuniversity.com/rules/axe/4.8/svg-img-alt?application=axechrome&lang=en

En l'état, les plugins d'accessibilité tels qu'axe-core signalent le manque de description sur les svg si ceux-ci possèdent un attribut role="img" sans avoir de <title>. La modification proposée ici permet d'avoir un html plus valide, avec l'idée que "tout svg ne possédant pas de description est un svg décoratif", ce qui fait sens. Il revient aux consommateur.ices de ce composant de déterminer si MksIcon est décoratif, ou si l'icône porte une information.

On pourrait aller plus loin en suivant les recommandations décrites ici : https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html
Mais ce sujet devrait être traité dans une épique accessibilité. Cette PR a été réalisée en quick win.